### PR TITLE
destroy method to pets controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'jbuilder', '~> 2.7'
 gem 'devise'
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
+gem 'faker'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
       railties (>= 3.2)
     erubi (1.10.0)
     execjs (2.7.0)
+    faker (2.15.1)
+      i18n (>= 1.6, < 2)
     ffi (1.14.2)
     font-awesome-sass (5.15.1)
       sassc (>= 1.11)
@@ -242,6 +244,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   devise
   dotenv-rails
+  faker
   font-awesome-sass
   jbuilder (~> 2.7)
   listen (~> 3.2)

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -18,5 +18,8 @@ class PetsController < ApplicationController
   end
 
   def destroy
+    @pet = Pet.find(params[:id])
+    @pet.destroy
+    redirect_to pets_path
   end
 end

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -19,6 +19,7 @@ class PetsController < ApplicationController
 
   def destroy
     @pet = Pet.find(params[:id])
+    authorize @pet
     @pet.destroy
     redirect_to pets_path
   end

--- a/app/policies/pet_policy.rb
+++ b/app/policies/pet_policy.rb
@@ -4,4 +4,7 @@ class PetPolicy < ApplicationPolicy
       scope.all
     end
   end
+  def destroy?
+    record.user == user
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'pages#home'
+  delete "pets/:id", to: "pets#destroy"
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resources :pets
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -23,7 +23,7 @@ puts "Creating pets..."
         description: Faker::Lorem.words(number: 4),
         price_per_day: [10,20,30].sample,
         location: Faker::Address.city,
-        user_id: [1,2,3].sample,
+        user_id: '1',
     )
 end
 puts "Finished!"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,25 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+require 'faker'
+
+puts "Cleaning database..."
+Pet.destroy_all
+
+puts "Creating pets..."
+# generate 20 pets
+(1..5).each do |id|
+    Pet.create!(
+# each user is assigned an id from 1-20
+        id: id,
+        name: Faker::Name.name,
+        species: ['cat','dog','monkey','lizard','snake','koala'].sample,
+        available: true,
+        age: [1,2,3].sample,
+        description: Faker::Lorem.words(number: 4),
+        price_per_day: [10,20,30].sample,
+        location: Faker::Address.city,
+        user_id: [1,2,3].sample,
+    )
+end
+puts "Finished!"


### PR DESCRIPTION
added destroy method and routes

  def destroy
    @pet = Pet.find(params[:id])
    @pet.destroy
    redirect_to pets_path
  end

Rails.application.routes.draw do
  devise_for :users
  root to: 'pages#home'
  delete "pets/:id", to: "pets#destroy"
  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
  resources :pets
end
